### PR TITLE
feat: add support for br numbers with or without leading 9

### DIFF
--- a/src/controllers/message.ts
+++ b/src/controllers/message.ts
@@ -41,12 +41,12 @@ export const send: RequestHandler = async (req, res) => {
 		const sessionId = req.params.sessionId;
 		const session = WhatsappService.getSession(sessionId)!;
 
-		const exists = await WhatsappService.jidExists(session, jid, type);
-		if (!exists) return res.status(400).json({ error: "JID does not exists" });
+		const validJid = await WhatsappService.validJid(session, jid, type);
+		if (!validJid) return res.status(400).json({ error: "JID does not exists" });
 
-		await updatePresence(session, WAPresence.Available, jid);
-		const result = await session.sendMessage(jid, message, options);
-		emitEvent("send.message", sessionId, { jid, result });
+		await updatePresence(session, WAPresence.Available, validJid);
+		const result = await session.sendMessage(validJid, message, options);
+		emitEvent("send.message", sessionId, { jid: validJid, result });
 		res.status(200).json(result);
 	} catch (e) {
 		const message = "An error occured during message send";

--- a/src/whatsapp/service.ts
+++ b/src/whatsapp/service.ts
@@ -282,18 +282,31 @@ class WhatsappService {
 		return WhatsappService.sessions.has(sessionId);
 	}
 
-	static async jidExists(session: Session, jid: string, type: "group" | "number" = "number") {
+	static async validJid(session: Session, jid: string, type: "group" | "number" = "number") {
 		try {
 			if (type === "number") {
 				const [result] = await session.onWhatsApp(jid);
-				return !!result?.exists;
+				if(result?.exists) {
+					return result.jid;
+				} else {
+					return null;
+				}
 			}
 
 			const groupMeta = await session.groupMetadata(jid);
-			return !!groupMeta.id;
+			if(groupMeta.id) {
+				return groupMeta.id;
+			} else {
+				return null;
+			}
 		} catch (e) {
-			return Promise.reject(e);
+			return null;
 		}
+	}
+
+	static async jidExists(session: Session, jid: string, type: "group" | "number" = "number") {
+		const validJid = await this.validJid(session, jid, type);
+		return !!validJid;
 	}
 }
 


### PR DESCRIPTION
The brazilian cellphone numbers were added a leading 9 a few years ago and the whatsapp may or may not include it on the jid. The proposed change makes the api fetch and use the correct jid prior to sending a message to ensure delivery.